### PR TITLE
Changelog: correct date typo

### DIFF
--- a/plugins/fix.common.problems.plg
+++ b/plugins/fix.common.problems.plg
@@ -13,7 +13,7 @@
 <PLUGIN name="&name;" author="&author;" version="&version;" launch="&launch;" pluginURL="&pluginURL;" icon="warning" min="6.7.0">
 
 <CHANGES>
-###2925.03.12
+###2025.03.12
 - Remove tests for unraid patch plugin on OS versions 7.0.0+
 
 ###2025.02.24


### PR DESCRIPTION
Correct date typo of 2925 instead of 2025