### PR TITLE
fix: recognize Community Applications CDN-proxied plugin URLs when matching the feed

### DIFF
--- a/source/fix.common.problems/usr/local/emhttp/plugins/fix.common.problems/include/helpers.php
+++ b/source/fix.common.problems/usr/local/emhttp/plugins/fix.common.problems/include/helpers.php
@@ -508,6 +508,25 @@ function getRedirectedURL($url) {
   return curl_getinfo($ch, CURLINFO_EFFECTIVE_URL);
 }
 
+####################################################################
+# Community Applications can serve some plugin artifacts through an  #
+# edge cache/CDN at  https://<host>/cdn/https://<upstream>  (for     #
+# reliability and to reduce load on the upstream origin).  Resolve   #
+# such a URL back to its upstream target so an installed plugin      #
+# still matches the application feed / moderation list.  Non-CDN     #
+# URLs are returned unchanged.                                       #
+####################################################################
+function resolveCAProxyURL($url) {
+  if ( ! is_string($url) || $url === "" ) {
+    return $url;
+  }
+  # The upstream URL is kept verbatim after the /cdn/ prefix.
+  if ( preg_match('#^https?://[^/]+/cdn/(https?://.+)$#i', $url, $matches) ) {
+    return $matches[1];
+  }
+  return $url;
+}
+
 ###############################################
 # Search array for a particular key and value #
 # returns the index number of the array       #

--- a/source/fix.common.problems/usr/local/emhttp/plugins/fix.common.problems/include/tests.php
+++ b/source/fix.common.problems/usr/local/emhttp/plugins/fix.common.problems/include/tests.php
@@ -777,7 +777,8 @@ function blacklistedPluginsInstalled() {
       if ( ! is_file("/var/log/plugins/$plugin") ) {
         continue;
       }
-      $pluginURL = getRedirectedURL(resolveCAProxyURL(exec("/usr/local/emhttp/plugins/dynamix.plugin.manager/scripts/plugin pluginURL /var/log/plugins/$plugin")));
+      $pluginPath = escapeshellarg("/var/log/plugins/$plugin");
+      $pluginURL = getRedirectedURL(resolveCAProxyURL(exec("/usr/local/emhttp/plugins/dynamix.plugin.manager/scripts/plugin pluginURL $pluginPath")));
       if ( isset($caModeration[$pluginURL]['Blacklist']) ) {
         addError("Blacklisted plugin <b>$plugin</b>","This plugin has been blacklisted and should no longer be used due to the following reason(s): <em><b>".$caModeration[$pluginURL]['ModeratorComment']."</b></em>  You should remove this plugin as its continued installation may cause adverse effects on your server.".addLinkButton("Plugins","/Plugins"));
       }
@@ -1189,7 +1190,8 @@ function pluginNotCompatible() {
   foreach ($installedPlugins as $plugin) {
     $minVer = "";
     $maxVer = "";
-    $pluginURL = getRedirectedURL(resolveCAProxyURL(exec("/usr/local/emhttp/plugins/dynamix.plugin.manager/scripts/plugin pluginURL /var/log/plugins/$plugin")));
+    $pluginPath = escapeshellarg("/var/log/plugins/$plugin");
+    $pluginURL = getRedirectedURL(resolveCAProxyURL(exec("/usr/local/emhttp/plugins/dynamix.plugin.manager/scripts/plugin pluginURL $pluginPath")));
 
     foreach ( $allApps as $app ) {
       if ( isset($app['Plugin']) ) {
@@ -2133,7 +2135,8 @@ function unknownPluginInstalled() {
           if ( ( $plugin == "fix.common.problems.plg") || ( $plugin == "dynamix.plg" ) || ($plugin == "unRAIDServer.plg") || ($plugin == "community.applications.plg") ) {
             continue;
           }
-          $pluginURL = resolveCAProxyURL(exec("/usr/local/emhttp/plugins/dynamix.plugin.manager/scripts/plugin pluginURL /var/log/plugins/$plugin"));
+          $pluginPath = escapeshellarg("/var/log/plugins/$plugin");
+          $pluginURL = resolveCAProxyURL(exec("/usr/local/emhttp/plugins/dynamix.plugin.manager/scripts/plugin pluginURL $pluginPath"));
           $flag = false;
           foreach ($allPlugins as $checkPlugin) {
             if ( is_array($checkPlugin['PluginURL']) ) {                  # due to coppit

--- a/source/fix.common.problems/usr/local/emhttp/plugins/fix.common.problems/include/tests.php
+++ b/source/fix.common.problems/usr/local/emhttp/plugins/fix.common.problems/include/tests.php
@@ -777,7 +777,7 @@ function blacklistedPluginsInstalled() {
       if ( ! is_file("/var/log/plugins/$plugin") ) {
         continue;
       }
-      $pluginURL = getRedirectedURL(exec("/usr/local/emhttp/plugins/dynamix.plugin.manager/scripts/plugin pluginURL /var/log/plugins/$plugin"));
+      $pluginURL = getRedirectedURL(resolveCAProxyURL(exec("/usr/local/emhttp/plugins/dynamix.plugin.manager/scripts/plugin pluginURL /var/log/plugins/$plugin")));
       if ( isset($caModeration[$pluginURL]['Blacklist']) ) {
         addError("Blacklisted plugin <b>$plugin</b>","This plugin has been blacklisted and should no longer be used due to the following reason(s): <em><b>".$caModeration[$pluginURL]['ModeratorComment']."</b></em>  You should remove this plugin as its continued installation may cause adverse effects on your server.".addLinkButton("Plugins","/Plugins"));
       }
@@ -1189,7 +1189,7 @@ function pluginNotCompatible() {
   foreach ($installedPlugins as $plugin) {
     $minVer = "";
     $maxVer = "";
-    $pluginURL = getRedirectedURL(exec("/usr/local/emhttp/plugins/dynamix.plugin.manager/scripts/plugin pluginURL /var/log/plugins/$plugin"));
+    $pluginURL = getRedirectedURL(resolveCAProxyURL(exec("/usr/local/emhttp/plugins/dynamix.plugin.manager/scripts/plugin pluginURL /var/log/plugins/$plugin")));
 
     foreach ( $allApps as $app ) {
       if ( isset($app['Plugin']) ) {
@@ -1784,7 +1784,7 @@ function updatePluginSupport() {
   if ( ! is_array($templates) ) { return; }
   $plugins = glob("/boot/config/plugins/*.plg");
   foreach ($plugins as $plugin) {
-    $pluginURL = plugin("pluginURL",$plugin);
+    $pluginURL = resolveCAProxyURL(plugin("pluginURL",$plugin));
     $pluginEntry = searchArray($templates,"PluginURL",$pluginURL);
     if ( $pluginEntry === false ) {
       $pluginEntry = searchArray($templates,"PluginURL",str_replace("https://raw.github.com/","https://raw.githubusercontent.com/",$pluginURL));
@@ -2133,7 +2133,7 @@ function unknownPluginInstalled() {
           if ( ( $plugin == "fix.common.problems.plg") || ( $plugin == "dynamix.plg" ) || ($plugin == "unRAIDServer.plg") || ($plugin == "community.applications.plg") ) {
             continue;
           }
-          $pluginURL = exec("/usr/local/emhttp/plugins/dynamix.plugin.manager/scripts/plugin pluginURL /var/log/plugins/$plugin");
+          $pluginURL = resolveCAProxyURL(exec("/usr/local/emhttp/plugins/dynamix.plugin.manager/scripts/plugin pluginURL /var/log/plugins/$plugin"));
           $flag = false;
           foreach ($allPlugins as $checkPlugin) {
             if ( is_array($checkPlugin['PluginURL']) ) {                  # due to coppit


### PR DESCRIPTION
## Why

Community Applications can serve some plugin artifacts (the feed, `.plg` manifests, icons, packages) through an edge cache/CDN at:

```
https://<host>/cdn/https://<upstream-url>
```

(for reliability and to reduce load on the upstream origin). A plugin installed that way reports the CDN URL as its `pluginURL`. FCP matches installed plugins against the application feed / moderation list by **exact (case-insensitive) string compare** of `pluginURL` against the feed's canonical upstream URLs — so a CDN-served plugin never matches.

On a server using the CDN, three checks misfire:

- **`unknownPluginInstalled()`** — flags the plugin as *"not known to Community Applications"* (false positive).
- **`blacklistedPluginsInstalled()`** — blacklist/deprecation detection silently stops matching (false negative).
- **version-incompatibility check** — `MinVer`/`MaxVer` enforcement silently stops matching (false negative).

## What

- Add `resolveCAProxyURL($url)` (`helpers.php`): if `$url` is a `…/cdn/https://<upstream>` CDN URL, return its upstream target; otherwise return it unchanged. Host-agnostic and a no-op for every non-CDN URL.
- Apply it at the four sites that read an installed plugin's `pluginURL` before comparing it to the feed/moderation list (`tests.php`). For the two sites already wrapped in `getRedirectedURL(...)`, resolve first then follow redirects.

## Testing

- `php -l` clean on both changed files.
- Unit-checked `resolveCAProxyURL()` across CDN URLs, query-string targets, plain upstream URLs (unchanged), a support link (unchanged), empty, and garbage inputs — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Community Applications CDN/edge-proxy URLs so plugin detection, compatibility verification, and support/status checks work reliably with redirected URL formats.
  * Hardened plugin URL processing to better support proxy-derived URLs and ensure consistent matching outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->